### PR TITLE
Fix passing a globals list to luacheck

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -22,7 +22,7 @@ class Luacheck(Linter):
         '--ignore:,': ['channel'],
         '--only:,': [],
         '--limit=': None,
-        '--globals: ': [],
+        '--globals:,': [],
     }
     comment_re = r'\s*--'
     inline_settings = 'limit'


### PR DESCRIPTION
luacheck receives a comma-delimited list of globals
