### PR TITLE
Upgrade pep257

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ python:
 # command to install dependencies
 install:
   - pip install flake8
-  - pip install pep257
+  - pip install pydocstyle
 # command to run tests
 script:
   - flake8 *.py --max-line-length=120
-  - pep257 . --ignore=D202
+  - pydocstyle .

--- a/linter.py
+++ b/linter.py
@@ -13,7 +13,6 @@ from SublimeLinter.lint import Linter
 
 
 class Luacheck(Linter):
-
     """Provides an interface to luacheck."""
 
     syntax = 'lua'


### PR DESCRIPTION
pep257 was renamed to pydocstyle. PEP257 itself was changed to disallow empty lines before class docstrings, fix that.