### PR TITLE
Run luacheck without using a temporary file.

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -16,7 +16,7 @@ class Luacheck(Linter):
     """Provides an interface to luacheck."""
 
     syntax = 'lua'
-    tempfile_suffix = 'lua'
+    # tempfile_suffix = 'lua'
     defaults = {
         '--ignore:,': ['channel'],
         '--only:,': [],
@@ -27,7 +27,7 @@ class Luacheck(Linter):
     inline_settings = 'limit'
     inline_overrides = ('ignore', 'only', 'globals')
     config_file = ('--config', '.luacheckrc', '~')
-    cmd = 'luacheck @ *'
+    cmd = 'luacheck --filename @ - *'
     regex = r'^(?P<filename>.+):(?P<line>\d+):(?P<col>\d+): (?P<message>.*)$'
 
     def build_args(self, settings):


### PR DESCRIPTION
This makes the current working dir the same as the file, allowing for
files entries in the config file to work.

Also, changes how we call luacheck to pass via stdin and the `--filename` argument, as suggested by [luacheck's documentation for editor plugins](http://luacheck.readthedocs.io/en/stable/cli.html#stable-interface-for-editor-plugins-and-tools).
