### PR TITLE
Use file paths relative to .luacheckrc

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -10,6 +10,7 @@
 """This module exports the Luacheck plugin class."""
 
 from SublimeLinter.lint import Linter
+import os.path
 
 
 class Luacheck(Linter):
@@ -39,6 +40,17 @@ class Luacheck(Linter):
                 index = args.index(arg)
                 values = args[index + 1].split(',')
                 args[index + 1:index + 2] = values
+            except ValueError:
+                pass
+
+        if self.filename:
+            try:
+                configIndex = args.index('--config')
+                configDir = os.path.dirname(args[configIndex + 1])
+                relativeFilename = os.path.relpath(self.filename, configDir)
+
+                args.append('--filename')
+                args.append(relativeFilename)
             except ValueError:
                 pass
 


### PR DESCRIPTION
Pass the path of the current file to luacheck, relative to the .luacheckrc .
This allows to specify configuration options using the files section in the luacheckrc:

> return {
>         std = "luajit",
>         files = {
>                 ["test"] = { redefined = false },
>         },
> }
