### PR TITLE
Handle case were there's no match

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -30,8 +30,11 @@ class Luacheck(Linter):
     )
 
     def split_match(self, match):
-        """Patch regex matches to highlight token correctly."""
-        match, line, col, error, warning, msg, _ = super().split_match(match)
-        col_end = int(match.group(3))
-        token_len = col_end - col
-        return match, line, col, error, warning, msg, "." * token_len
+        if match:
+            """Patch regex matches to highlight token correctly."""
+            match, line, col, error, warning, msg, _ = super().split_match(match)
+            col_end = int(match.group(3))
+            token_len = col_end - col
+            return match, line, col, error, warning, msg, "." * token_len
+        else:
+            return super().split_match(match)

--- a/linter.py
+++ b/linter.py
@@ -30,6 +30,12 @@ class Luacheck(Linter):
     )
 
     def split_match(self, match):
+        """
+        Extract and return values from match.
+
+        The argument match may be None, in which case the call to super().split_match(match) will return
+        None values for all values except msg which will be an empty string
+        """
         if match:
             """Patch regex matches to highlight token correctly."""
             match, line, col, error, warning, msg, _ = super().split_match(match)


### PR DESCRIPTION
It seems that sometimes when something goes wrong with Sublime Linter the match value may be falsey. Looking at linter.py, it checks match and may return it and a lot of None values if the it is not truthy. See:
https://github.com/SublimeLinter/SublimeLinter3/blob/master/lint/linter.py

I noticed this issue because match is None if an error occurs earlier in SublimeLinter.

I propose imitating the super function. An alternative would be to check the results of the call to super().split_match and then to just return the results if match or col are None.