### PR TITLE
fix display of links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ SublimeLinter-luacheck
 
 [![Build Status](https://travis-ci.org/SublimeLinter/SublimeLinter-luacheck.svg)](https://travis-ci.org/SublimeLinter/SublimeLinter-luacheck)
 
-This linter plugin for [SublimeLinter](https://github.com/SublimeLinter/SublimeLinter) provides an interface to [luacheck](http://luacheck.readthedocs.io.
+This linter plugin for [SublimeLinter](https://github.com/SublimeLinter/SublimeLinter) provides an interface to [luacheck](http://luacheck.readthedocs.io).
 It will be used with files that have the "Lua" syntax.
 
 
@@ -14,7 +14,7 @@ SublimeLinter must be installed in order to use this plugin.
 Please use [Package Control](https://packagecontrol.io) to install the linter plugin.
 
 Before using this plugin, ensure that `luacheck` is installed on your system.
-To install `luacheck`, follow the instructions at the [luacheck home page](http://luacheck.readthedocs.io.
+To install `luacheck`, follow the instructions at the [luacheck home page](http://luacheck.readthedocs.io).
 
 Please make sure that the path to `luacheck` is available to SublimeLinter.
 The docs cover [troubleshooting PATH configuration](http://sublimelinter.com/en/latest/troubleshooting.html#finding-a-linter-executable).


### PR DESCRIPTION
Hello - this is just a very minor detail I noticed.

The closing brackets for the links in the readme were missing, so the display of them was broken.
